### PR TITLE
Get Release ID from file `/etc/heroku/release_id`

### DIFF
--- a/buildpacks/release-phase/README.md
+++ b/buildpacks/release-phase/README.md
@@ -44,9 +44,9 @@ This command must output release artifacts into `/workspace/static-artifacts/`. 
 
 ## Configuration: runtime environment vars
 
-### `RELEASE_ID`
+### `/etc/heroku/release_id` or `RELEASE_ID`
 
-**Required.** Should be provided by the runtime environment, such as a UUID or version number.
+**Required.** Should be provided by the runtime environment, such as a UUID or version number, either set in the file `/etc/heroku/release_id`, or as the environment variable `RELEASE_ID`.
 
 Artifacts are stored at the `STATIC_ARTIFACTS_URL` with the name `release-<RELEASE_ID>.tgz`.
 

--- a/buildpacks/release-phase/src/bin/load-release-artifacts.rs
+++ b/buildpacks/release-phase/src/bin/load-release-artifacts.rs
@@ -7,18 +7,13 @@ use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;
 use libcnb::exec_d::write_exec_d_program_output;
 
-use release_artifacts::load;
+use release_artifacts::{capture_env, load};
 
 #[tokio::main]
 async fn main() {
     let source_dir = Path::new("static-artifacts");
 
-    let mut env = HashMap::new();
-    for (key, value) in env::vars() {
-        if key.starts_with("STATIC_ARTIFACTS_") || key == "RELEASE_ID" {
-            env.insert(key, value);
-        }
-    }
+    let env = capture_env();
 
     match load(&env, source_dir).await {
         Ok(loaded_key) => {

--- a/buildpacks/release-phase/src/bin/load-release-artifacts.rs
+++ b/buildpacks/release-phase/src/bin/load-release-artifacts.rs
@@ -1,7 +1,7 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use std::{collections::HashMap, env, path::Path};
+use std::{collections::HashMap, path::Path};
 
 use libcnb::data::exec_d::ExecDProgramOutputKey;
 use libcnb::data::exec_d_program_output_key;

--- a/buildpacks/release-phase/src/bin/load-release-artifacts.rs
+++ b/buildpacks/release-phase/src/bin/load-release-artifacts.rs
@@ -13,7 +13,7 @@ use release_artifacts::{capture_env, load};
 async fn main() {
     let source_dir = Path::new("static-artifacts");
 
-    let env = capture_env();
+    let env = capture_env(Path::new("/etc/heroku"));
 
     match load(&env, source_dir).await {
         Ok(loaded_key) => {

--- a/buildpacks/release-phase/src/bin/save-release-artifacts.rs
+++ b/buildpacks/release-phase/src/bin/save-release-artifacts.rs
@@ -1,9 +1,9 @@
 // Required due to: https://github.com/rust-lang/rust/issues/95513
 #![allow(unused_crate_dependencies)]
 
-use std::{collections::HashMap, env, path::Path};
+use std::{env, path::Path};
 
-use release_artifacts::save;
+use release_artifacts::{capture_env, save};
 
 #[tokio::main]
 async fn main() {
@@ -14,12 +14,7 @@ async fn main() {
     }
     let source_dir = Path::new(&args[1]);
 
-    let mut env = HashMap::new();
-    for (key, value) in env::vars() {
-        if key.starts_with("STATIC_ARTIFACTS_") || key == "RELEASE_ID" {
-            env.insert(key, value);
-        }
-    }
+    let env = capture_env();
 
     match save(&env, source_dir).await {
         Ok(()) => {

--- a/buildpacks/release-phase/src/bin/save-release-artifacts.rs
+++ b/buildpacks/release-phase/src/bin/save-release-artifacts.rs
@@ -14,7 +14,7 @@ async fn main() {
     }
     let source_dir = Path::new(&args[1]);
 
-    let env = capture_env();
+    let env = capture_env(Path::new("/etc/heroku"));
 
     match save(&env, source_dir).await {
         Ok(()) => {

--- a/common/release_artifacts/dyno-metadata-for-test-d5af7e2f-352c-4f0a-b9e5-cd5260047305/release_id
+++ b/common/release_artifacts/dyno-metadata-for-test-d5af7e2f-352c-4f0a-b9e5-cd5260047305/release_id
@@ -1,1 +1,0 @@
-test-release-id-from-file

--- a/common/release_artifacts/dyno-metadata-for-test-d5af7e2f-352c-4f0a-b9e5-cd5260047305/release_id
+++ b/common/release_artifacts/dyno-metadata-for-test-d5af7e2f-352c-4f0a-b9e5-cd5260047305/release_id
@@ -1,0 +1,1 @@
+test-release-id-from-file

--- a/common/release_artifacts/src/lib.rs
+++ b/common/release_artifacts/src/lib.rs
@@ -22,7 +22,7 @@ use tokio as _;
 use uuid::{self as _, Uuid};
 
 #[must_use]
-pub fn capture_env() -> HashMap<String, String> {
+pub fn capture_env(dyno_metadata_dir: &Path) -> HashMap<String, String> {
     let mut env = HashMap::new();
     for (key, value) in env::vars() {
         if key.starts_with("STATIC_ARTIFACTS_") || key == "RELEASE_ID" {
@@ -30,7 +30,7 @@ pub fn capture_env() -> HashMap<String, String> {
         }
     }
     // Override RELEASE_ID with value from the dyno filesystem, when present.
-    File::open("/etc/heroku/release_id")
+    File::open(dyno_metadata_dir.join("release_id"))
         .map_or(None, |mut file| {
             let mut buffer = String::new();
             if file.read_to_string(&mut buffer).is_ok() {
@@ -463,7 +463,7 @@ mod tests {
         collections::HashMap,
         env,
         fs::{self, File},
-        io::Read,
+        io::{Read, Write},
         path::Path,
     };
 
@@ -487,12 +487,33 @@ mod tests {
     #[test]
     fn capture_env_succeeds() {
         env::set_var("RELEASE_ID", "test-release-id");
-        let result = capture_env();
+        let result = capture_env(Path::new("does-not-exist"));
         env::remove_var("RELEASE_ID");
         assert_eq!(
             result.get("RELEASE_ID"),
             Some(&"test-release-id".to_string())
         );
+    }
+
+    #[test]
+    fn capture_env_with_metadata_file_succeeds() {
+        let unique = Uuid::new_v4();
+        let dyno_metadata_dir = format!("dyno-metadata-for-test-{unique}");
+        let dyno_metadata_path = Path::new(&dyno_metadata_dir);
+        fs::create_dir_all(dyno_metadata_path).expect("dyno metadata dir should be created");
+        let release_id_path = dyno_metadata_path.join("release_id");
+        File::create(&release_id_path)
+            .and_then(|mut file| file.write_all(b"test-release-id-from-file"))
+            .expect("dyno metadata file shoud be written");
+
+        env::set_var("RELEASE_ID", "test-release-id-from-env");
+        let result = capture_env(dyno_metadata_path);
+        env::remove_var("RELEASE_ID");
+        assert_eq!(
+            result.get("RELEASE_ID"),
+            Some(&"test-release-id-from-file".to_string())
+        );
+        fs::remove_dir_all(dyno_metadata_path).unwrap_or_default();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Improvement to read the dyno metadata from the Fir dyno filesystem.